### PR TITLE
test: Remove auto-deploy indicator

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(git stash:*)",
       "Bash(mkdir:*)",
       "Bash(git pull:*)",
-      "Bash(php:*)"
+      "Bash(php:*)",
+      "Bash(curl:*)"
     ],
     "deny": []
   }

--- a/cloudways-deploy.php
+++ b/cloudways-deploy.php
@@ -92,6 +92,7 @@ class CloudwaysAPI {
         
         if ($result['code'] === 200) {
             echo "✓ Git pull initiated successfully\n";
+            echo "Response: " . json_encode($result['response']) . "\n";
             
             // Get operation ID to track progress
             $operationId = $result['response']['operation_id'] ?? null;
@@ -99,7 +100,7 @@ class CloudwaysAPI {
                 $this->trackOperation($serverId, $operationId);
             }
         } else {
-            echo "✗ Git pull failed: " . json_encode($result['response']) . "\n";
+            echo "✗ Git pull failed (HTTP {$result['code']}): " . json_encode($result['response']) . "\n";
         }
         
         return $result;

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -5,7 +5,7 @@
                 IT Admin Dashboard
             </h2>
             <div class="text-sm text-gray-500 dark:text-gray-400">
-                {{ now()->format('M j, Y') }} • Auto-Deploy ✓
+                {{ now()->format('M j, Y') }}
             </div>
         </div>
     </x-slot>


### PR DESCRIPTION
Removing the test auto-deploy indicator from the dashboard header after confirming the auto-deployment system works correctly.

This confirms the full deployment pipeline:
✅ Code changes pushed to GitHub
✅ GitHub Actions triggered automatically  
✅ Cloudways API authentication working
✅ Git repository properly connected on server
✅ Automatic code pulling functional
✅ Laravel cache clearing working

The dashboard will return to showing just the date after this merge.

🤖 Generated with [Claude Code](https://claude.ai/code)