### PR TITLE
Fix API routes not loading - enable SMS endpoints

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )


### PR DESCRIPTION
## Problem
The `/api/sms/test` endpoint was returning 404 because API routes weren't being loaded.

## Root Cause
The `bootstrap/app.php` file was missing the API routes configuration, so `routes/api.php` was never being loaded.

## Solution
Added `api: __DIR__.'/../routes/api.php'` to the routing configuration in `bootstrap/app.php`.

## Result
✅ SMS test endpoint now works: `/api/sms/test`  
✅ SMS webhook endpoint now works: `/api/sms/webhook`  
✅ Both routes properly registered with `/api/` prefix  

## Test Plan
- [x] Verify routes are loaded: `php artisan route:list --path=api`
- [x] Check test endpoint works locally
- [ ] Test production endpoint after deployment

This fixes the SMS webhook system foundation\! 🎯

🤖 Generated with [Claude Code](https://claude.ai/code)