### PR TITLE
Add SMS routes to web.php as server config fallback

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\MonitorController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SMSController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -25,3 +26,7 @@ Route::middleware('auth')->group(function () {
 });
 
 require __DIR__.'/auth.php';
+
+// SMS webhook endpoints (moved from API routes due to server config)
+Route::get('/sms/test', [SMSController::class, 'test'])->name('sms.test');
+Route::post('/sms/webhook', [SMSController::class, 'handleIncomingMessage'])->name('sms.webhook');


### PR DESCRIPTION
## Problem
The `/api/sms/test` endpoint is still returning 404, likely due to server configuration not properly handling `/api/` routes.

## Solution
Added SMS routes to web.php as a fallback, so they're available at both:
- `/api/sms/test` and `/api/sms/webhook` (API routes)
- `/sms/test` and `/sms/webhook` (Web routes)

## Routes Added
```php
// SMS webhook endpoints (moved from API routes due to server config)
Route::get('/sms/test', [SMSController::class, 'test'])->name('sms.test');
Route::post('/sms/webhook', [SMSController::class, 'handleIncomingMessage'])->name('sms.webhook');
```

## Test URLs
After deployment, test both:
- https://admin.schroeder247.com/sms/test ✅ Should work
- https://admin.schroeder247.com/api/sms/test ❓ May not work due to server config

## Twilio Configuration
Use this webhook URL (without /api/ prefix):
```
https://admin.schroeder247.com/sms/webhook
```

This ensures SMS functionality works regardless of server API route configuration\! 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)