### PR TITLE
Fix ZabbixHostController authorize method error

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests, ValidatesRequests;
 }


### PR DESCRIPTION
## Summary
- Fix "Call to undefined method authorize()" error when accessing Zabbix host View/Settings buttons
- Add AuthorizesRequests and ValidatesRequests traits to base Controller class
- Extend Laravel's BaseController for proper functionality
- Enable authorization policy enforcement for Zabbix host routes

## Test plan
- [x] Verify ZabbixHostController syntax is correct
- [x] Confirm routes load without errors
- [x] Test that Laravel application bootstraps successfully
- [x] Authorization methods are now available to all controllers

## Root Cause
The base `app/Http/Controllers/Controller.php` was empty and didn't extend Laravel's controller or include the necessary traits for authorization functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)