### PR TITLE
Add Zabbix Alert Severity Settings and Event History

### DIFF
--- a/app/Http/Controllers/ZabbixHostController.php
+++ b/app/Http/Controllers/ZabbixHostController.php
@@ -53,6 +53,8 @@ class ZabbixHostController extends Controller
             'notification_phone' => 'nullable|string|max:20',
             'email_notifications' => 'boolean', 
             'notification_email' => 'nullable|email|max:255',
+            'severity_settings' => 'nullable|array',
+            'severity_settings.*' => 'boolean',
         ]);
 
         $zabbixHost->update($validated);

--- a/app/Models/ZabbixHost.php
+++ b/app/Models/ZabbixHost.php
@@ -24,12 +24,14 @@ class ZabbixHost extends Model
         'notification_phone',
         'email_notifications',
         'notification_email',
+        'severity_settings',
         'last_synced_at',
     ];
 
     protected $casts = [
         'interfaces' => 'array',
         'groups' => 'array',
+        'severity_settings' => 'array',
         'monitored' => 'boolean',
         'sms_notifications' => 'boolean',
         'email_notifications' => 'boolean',

--- a/database/migrations/2025_08_06_233232_add_severity_settings_to_zabbix_hosts_table.php
+++ b/database/migrations/2025_08_06_233232_add_severity_settings_to_zabbix_hosts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('zabbix_hosts', function (Blueprint $table) {
+            $table->json('severity_settings')->nullable()->after('notification_email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('zabbix_hosts', function (Blueprint $table) {
+            $table->dropColumn('severity_settings');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Added configurable alert severity settings for Zabbix hosts  
- Implemented comprehensive event history display with status indicators
- Enhanced notification filtering based on user-selected severity levels

## Changes Made
- **Database**: Added `severity_settings` JSON field to `zabbix_hosts` table
- **Backend**: Updated ZabbixHost model, controller, and ZabbixAlertJob to support severity filtering
- **Frontend**: Enhanced Zabbix host show page with event history and severity settings display
- **Logic**: Modified alert job to check severity settings before sending notifications

## Features
- Users can now select which severity levels (disaster, high, average, warning, information) trigger notifications
- Event history shows all past events with status indicators (ACTIVE/RESOLVED), duration, and recovery times
- Severity settings are visually displayed on the host details page
- Default behavior maintains existing notification levels (disaster and high) when no settings configured

## Test Plan
- [x] Database migration runs successfully
- [x] Build completes without errors
- [x] Core functionality tests pass
- [x] Forms handle severity settings correctly
- [x] Event history displays properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)