### PR TITLE
Fix JSON Decode Error in Zabbix Host Edit Page

### DIFF
--- a/resources/views/zabbix-hosts/edit.blade.php
+++ b/resources/views/zabbix-hosts/edit.blade.php
@@ -124,7 +124,7 @@
                             <div class="space-y-3">
                                 @foreach(['disaster', 'high', 'average', 'warning', 'information'] as $severity)
                                     @php
-                                        $severitySettings = old('severity_settings', json_decode($zabbixHost->severity_settings ?? '{}', true));
+                                        $severitySettings = old('severity_settings', $zabbixHost->severity_settings ?? []);
                                         $isChecked = $severitySettings[$severity] ?? ($severity === 'disaster' || $severity === 'high');
                                         $severityColor = match($severity) {
                                             'disaster' => 'red-600',


### PR DESCRIPTION
## Summary
Fixed a JSON decode error that occurred when accessing the edit settings page for Zabbix hosts.

## Issue
**Error**: `json_decode(): Argument #1 ($json) must be of type string, array given`
**Location**: Zabbix host edit page (line 127)
**Trigger**: Clicking "Edit Settings" on a host that has severity settings configured

## Root Cause
The `severity_settings` field was being passed to `json_decode()` even though the ZabbixHost model already has a cast that automatically converts the JSON field to an array. This resulted in trying to decode an array instead of a string.

## Fix
- Removed unnecessary `json_decode()` call
- Now directly uses `$zabbixHost->severity_settings` as an array
- Maintains backward compatibility with `??` fallback to empty array

## Code Change
```php
// Before (causing error)
$severitySettings = old('severity_settings', json_decode($zabbixHost->severity_settings ?? '{}', true));

// After (fixed)
$severitySettings = old('severity_settings', $zabbixHost->severity_settings ?? []);
```

## Testing
- Edit settings page now loads without errors
- Severity checkboxes still display correctly with existing settings
- Form submission continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)