### PR TITLE
Fix Sync Hosts button to run immediately instead of queuing

### DIFF
--- a/app/Http/Controllers/ZabbixHostController.php
+++ b/app/Http/Controllers/ZabbixHostController.php
@@ -79,11 +79,13 @@ class ZabbixHostController extends Controller
                     ->with('error', 'Failed to connect to Zabbix server: ' . $connectionTest['message']);
             }
 
-            SyncZabbixHostsJob::dispatch(auth()->id());
+            // Run sync job directly instead of queuing for immediate results
+            $job = new SyncZabbixHostsJob(auth()->id());
+            $job->handle();
 
             return redirect()
                 ->back()
-                ->with('success', 'Zabbix host synchronization started. This may take a few minutes to complete.');
+                ->with('success', 'Zabbix hosts synchronized successfully!');
 
         } catch (\Exception $e) {
             Log::error('Manual Zabbix sync failed', ['error' => $e->getMessage()]);


### PR DESCRIPTION
## Summary
- Fixed Sync Hosts button to execute synchronously instead of queuing
- Removed dependency on queue worker for production environment  
- Provides immediate user feedback upon completion

## Changes
- Modified `ZabbixHostController::sync()` to run `SyncZabbixHostsJob` directly
- Updated success message to reflect immediate completion
- Maintains same functionality with synchronous execution

## Test plan
- [x] Click Sync Hosts button and verify immediate execution
- [x] Confirm success message appears right away
- [x] Verify hosts are synchronized without queue worker running

🤖 Generated with [Claude Code](https://claude.ai/code)