### PR TITLE
Fix Zabbix API sortfield parameter error for problem.get

### DIFF
--- a/app/Services/ZabbixService.php
+++ b/app/Services/ZabbixService.php
@@ -141,7 +141,7 @@ class ZabbixService
                 'source' => 0,
                 'object' => 0,
                 'recent' => true,
-                'sortfield' => 'clock',
+                'sortfield' => 'eventid',
                 'sortorder' => 'DESC',
                 'limit' => 100,
             ];


### PR DESCRIPTION
## Summary
- Fixed another Zabbix 7.4 API compatibility issue
- Changed `sortfield` from `'clock'` to `'eventid'` in `problem.get` method
- Resolves error: `"Invalid parameter "/sortfield/1": value must be "eventid"`

## Changes
- Updated `sortfield` parameter in `ZabbixService::getProblems()`
- Maintains DESC sorting order for most recent events first
- Ensures compatibility with Zabbix 7.4 API requirements

## Technical Details
The Zabbix 7.4 API `problem.get` method only accepts `"eventid"` as a valid `sortfield` value, unlike other API methods that support multiple sort fields.

🤖 Generated with [Claude Code](https://claude.ai/code)