### PR TITLE
Add 'resolved' status to zabbix_events enum

### DIFF
--- a/database/migrations/2025_08_07_072232_update_zabbix_events_status_enum.php
+++ b/database/migrations/2025_08_07_072232_update_zabbix_events_status_enum.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('zabbix_events', function (Blueprint $table) {
+            // Update the status enum to include 'resolved'
+            $table->enum('status', ['problem', 'ok', 'resolved'])->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('zabbix_events', function (Blueprint $table) {
+            // Revert back to original enum values
+            $table->enum('status', ['problem', 'ok'])->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Fixed SQL error: `Data truncated for column 'status'` when marking events as resolved
- Added `'resolved'` as valid enum value for zabbix_events status column
- Database migration safely updates enum with proper rollback

## Problem
The sync process was trying to set event status to `'resolved'` but the database enum only allowed `['problem', 'ok']`. This caused SQL errors when trying to mark suppressed/resolved problems as inactive.

Error: `SQLSTATE[01000]: Warning: 1265 Data truncated for column 'status'`

## Solution
- **Database Migration**: Updated enum to `['problem', 'ok', 'resolved']`  
- **Safe Migration**: Includes proper down() method for rollback
- **Better Status Tracking**: Can now distinguish between 'ok' and 'resolved' events

## Changes
- Created migration to update zabbix_events status enum
- Ran migration to update database schema
- Resolves sync errors for suppressed/resolved problems

🤖 Generated with [Claude Code](https://claude.ai/code)