### PR TITLE
Redirect Zabbix host updates to monitors page

### DIFF
--- a/app/Http/Controllers/ZabbixHostController.php
+++ b/app/Http/Controllers/ZabbixHostController.php
@@ -72,7 +72,7 @@ class ZabbixHostController extends Controller
         $zabbixHost->update($validated);
 
         return redirect()
-            ->route('zabbix-hosts.index')
+            ->route('monitors.index')
             ->with('success', 'Zabbix host notification settings updated successfully.');
     }
 


### PR DESCRIPTION
## Summary
🔄 **Better UX flow** - Zabbix host setting updates now redirect back to monitors page
🎯 **Logical navigation** - Users stay in their primary workflow after making changes

## Problem
When users updated Zabbix host settings from the unified monitors page, they were redirected to the separate `zabbix-hosts` page, breaking their workflow and forcing them to navigate back.

## Solution
- **Simple redirect change**: `zabbix-hosts.index` → `monitors.index`
- **Preserves success message**: Users still get confirmation feedback
- **Maintains workflow**: Users stay in the main monitoring interface

## User Experience
**Before**: Monitors Page → Edit Zabbix Host → Zabbix Hosts Page ❌  
**After**: Monitors Page → Edit Zabbix Host → Monitors Page ✅

Perfect for the unified monitoring interface\! 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)